### PR TITLE
Use execFile to execute idle.exe

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 var exec = require('child_process').exec;
+var execFile = require('child_process').execFile;
 var os = require('os');
 var path = require('path');
 
@@ -11,8 +12,8 @@ idle.tick = function (callback) {
 	callback = callback || function (){};
 
 	if (/^win/.test(process.platform)) {
-		var cmd = '"' + path.join( __dirname, 'bin', 'idle.exe') + '"';
-		exec(cmd, function (error, stdout, stderr) {
+		var cmd = path.join( __dirname, 'bin', 'idle.exe');
+		execFile(cmd, function (error, stdout, stderr) {
 			if(error) {
 				callback(0, error);
 				return;


### PR DESCRIPTION
This is a more efficient command to use regardless, but more importantly this allows the module to work on in Electron as the execFile command is wrapped to work with asar archives. See:

https://github.com/atom/electron/blob/master/docs/tutorial/application-packaging.md#extra-unpacking-on-some-apis