### PR TITLE
Fixed idle.exe not found in electron asar package

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ var exec = require('child_process').exec;
 var execFile = require('child_process').execFile;
 var os = require('os');
 var path = require('path');
+require('hazardous');
 
 var listeners = [],
     idle = {};

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "type": "git",
     "url": "git://github.com/Teamwork/node-afk.git"
   },
-  "dependencies": {},
+  "dependencies": {
+    "hazardous": "^0.3.0"
+  },
   "devDependencies": {},
   "main": "index.js"
 }


### PR DESCRIPTION
node-afk module gets unpacked while using electron-packager and __dirname points to app.asar instead of app.asar.unpacked so I added this module hazardous which checks for existence of file and chooses path between __dirname and app.asar.unpacked.